### PR TITLE
fix: Connection.go to properly close connection if the connection is not nil.  

### DIFF
--- a/pkg/resolver/connection.go
+++ b/pkg/resolver/connection.go
@@ -13,7 +13,7 @@ import (
 
 func (r *Resolver) CloseConnection() {
 	if r != nil {
-		if r.nc == nil {
+		if r.nc != nil {
 			r.nc.Close()
 		}
 	}


### PR DESCRIPTION
Closes Issue #25